### PR TITLE
Added support for multiples cnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ kind: Ingress
 metadata:
   name: kopf-example-2
   annotations:
-    cname: blog.asksven.io
+    cnames: blog.asksven.io=cname1,foo.asksven.io=cname2
 ```
 
 ## Run

--- a/obj.yaml
+++ b/obj.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   name: kopf-example-2
   annotations:
-    cname: blog.asksven.io
+    cnames: foo.ext.stg.asksven.io=blog.asksven.io
 spec:
   ingressClassName: nginx-example
   rules:


### PR DESCRIPTION
Since the ingress object supports multiple host entries we have changed the annotation:

- the new name is `cnames`
- `cnames` is now a comma separated list of tuples `<hostname>=<cname>`
- the operator has been updated to handle the tuples, adding the possibility to have a different cname per hostname